### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   deployment:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/asp8964/phonebook-solid/security/code-scanning/1](https://github.com/asp8964/phonebook-solid/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block to the `deployment` job, restricting the GITHUB_TOKEN permissions to the minimum necessary. Since the `deployment` job does not appear to need any write permissions (all its steps are install/build/lint/test and notifications via webhook), it’s safest to grant read-only permissions for repository contents. You should insert:

```yaml
permissions:
  contents: read
```

directly under the job name, i.e., after line 12 and before line 13, indented to match the other job keys. No other imports or definitions are necessary. Do not modify the root of the workflow, nor other jobs; just add this explicit block to the `deployment` job to satisfy both CodeQL and the security best practice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
